### PR TITLE
Test for decreasing average elo score over multiple games

### DIFF
--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -70,6 +70,23 @@ describe Game do
       player2.ranks.first.value.should < 1000
     }
   end
+
+  describe "#update_player_rank_multiple" do
+    it { 
+      sport = FactoryGirl.build(:sport, :name => '9ball')
+
+      player1 = FactoryGirl.create(:player)
+      player2 = FactoryGirl.create(:player)
+
+      (1..100).each do |i|
+        FactoryGirl.build(:game, :sport => sport, :winner => player1, :loser => player2).update_player_rank
+        FactoryGirl.build(:game, :sport => sport, :winner => player2, :loser => player1).update_player_rank
+      end
+
+      player1.ranks.first.value.should > 950 
+      player2.ranks.first.value.should > 950
+    }
+  end
   
   describe "#after_save" do
     it {


### PR DESCRIPTION
This test shows a decreasing elo score over multiple alternating games between 2 players. Over 1100 games, the score is reduced to 0. Wasn't sure what the elo scores should equal exactly, but >950 should be correct.
